### PR TITLE
Fix ruby 3 bug for the download method

### DIFF
--- a/lib/ilovepdf/task.rb
+++ b/lib/ilovepdf/task.rb
@@ -150,7 +150,7 @@ module Ilovepdf
       content_disposition = response.headers[:content_disposition]
 
       if match_data = /filename\*\=utf-8\'\'([\W\w]+)/.match(content_disposition)
-        filename = URI.unescape(match_data[1].gsub('"', ''))
+        filename = URI.decode_www_form_component(match_data[1].gsub('"', ''))
       else
         match_data  = / .*filename=\"([\W\w]+)\"/.match(content_disposition)
         filename =  match_data[1].gsub('"', '')


### PR DESCRIPTION
the `URI#unescape` method does not exists anymore on ruby 3. 
I used the `#decode_www_form_component` method instead to replace '%20'-like characters.

Fix bug #12 